### PR TITLE
fix URI.parse() ascii only errors

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -39,7 +39,7 @@ after_initialize do
       guardian.ensure_featured_link_category!(category.to_i)
 
 
-      uri = URI.parse(@params[:featured_link])
+      uri = URI.parse(URI.encode(@params[:featured_link]))
       if uri.scheme.nil?
         uri = URI.parse("http://#{@params[:featured_link]}")
       end


### PR DESCRIPTION
Currently, URLs with non-ASCII characters don't work. An example: http://www.m.lapsi.al/ide/2016/10/03/fenomeni-trump-dhe-leksioni-më-i-madh-i-gazetarisë 

Encoding URL before parsing fixes the issue. 
