### PR TITLE
DEV: Remove GLOBAL_REPORTS reference

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -142,8 +142,6 @@ after_initialize do
   end
 
   if Report.respond_to?(:add_report)
-    AdminDashboardData::GLOBAL_REPORTS << FEATURED_LINK_FIELD_NAME
-
     Report.add_report(FEATURED_LINK_FIELD_NAME) do |report|
       report.data = []
       link_topics = TopicCustomField.where(name: FEATURED_LINK_FIELD_NAME)


### PR DESCRIPTION
This is no longer used in Discourse core, so it is safe
to remove. This const will also be removed altogether
in Discourse core.